### PR TITLE
Add destroy command

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "coffee-script": "~1.7.1",
     "commander": "~2.2.0",
     "fleetctl": "~0.1.3",
+    "lodash": "~2.4.1",
     "mkdirp": "~0.5.0",
     "property-accessors": "~1.1.0",
     "q": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "coffee-script": "~1.7.1",
     "commander": "~2.2.0",
     "fleetctl": "~0.1.3",
+    "inquirer": "~0.5.1",
     "lodash": "~2.4.1",
     "mkdirp": "~0.5.0",
     "property-accessors": "~1.1.0",

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -5,6 +5,7 @@ program
 
 commands = [
   require './deploy'
+  require './destroy'
   require './list'
 ]
 

--- a/src/destroy.coffee
+++ b/src/destroy.coffee
@@ -1,0 +1,52 @@
+q = require 'q'
+_ = require 'lodash'
+string = require 'string'
+
+log = require './log'
+fleetctl = require './fleetctl'
+cordagefile = require './cordagefile'
+Service = require './service'
+
+# Public: Destroys all units associated with the given service.
+module.exports =
+class Destroy
+
+  constructor: (program) ->
+    program
+    .command 'destroy <service>'
+    .description 'stops and destroys all units for the given service'
+    .action @run
+
+  # Public: Run the destroy command.
+  run: (serviceName) ->
+    service = null
+    cordagefile.read()
+
+    .then ->
+      # find service by name
+      service = _.find cordagefile.services, name: serviceName
+      throw new Error "Service \"#{serviceName}\" not found" unless service?
+
+    .then -> fleetctl.listUnits()
+
+    .then (units) ->
+      # find only units associated with the service we want to destroy
+      _.filter units, (unit) ->
+        true if Service.fromUnitName(unit.unit, [ service ]) is service
+
+    .then (units) ->
+      if units.length is 0
+        log.action 'No units found, nothing to destroy.'
+        return
+
+      log.action "Destroying #{serviceName}..."
+
+      # run `fleet destroy` for each unit
+      q.all units.map (unit) ->
+        log.info string(unit.unit).chompRight('.service').toString(), 'Destroying'
+        fleetctl.destroy unit.unit
+
+    .then -> log.action "#{serviceName} has been destroyed."
+
+    .catch (err) ->
+      log.error "An error has occured whilst destroying \"#{serviceName}\"", err.toString()

--- a/src/fleetctl.coffee
+++ b/src/fleetctl.coffee
@@ -31,3 +31,13 @@ module.exports =
       deferred.resolve() unless err
 
     return deferred.promise
+
+  # Public: Run `fleetctl destroy [units]`
+  destroy: (units) ->
+    deferred = q.defer()
+
+    fleetctl.destroy units, (err) ->
+      deferred.reject err if err
+      deferred.resolve() unless err
+
+    return deferred.promise

--- a/test/destroy.spec.coffee
+++ b/test/destroy.spec.coffee
@@ -1,0 +1,56 @@
+proxyquire = require 'proxyquire'
+q = require 'q'
+
+program = null
+cordagefile = null
+fleetctl = null
+
+describe 'cordage destroy', ->
+
+  beforeEach ->
+    program = require './mocks/program'
+
+    cordagefile =
+      read: -> q {}
+      services: []
+
+    fleetctl = jasmine.createSpyObj 'fleetctl', ['listUnits', 'destroy']
+
+  it 'should destroy any units associated with the given service', (done) ->
+    Destroy = proxyquire '../src/destroy',
+      './cordagefile': cordagefile
+      './fleetctl': fleetctl
+
+    destroy = new Destroy program
+
+    fleetctl.listUnits.andReturn q([
+      { unit: 'test.v1.1.service', state: 'activated', active: 'running', ip: '127.0.0.1' }
+      { unit: 'app.v1.1.service', state: 'activated', active: 'failed', ip: '127.0.0.2' }
+    ])
+
+    cordagefile.services.push
+      name: 'app'
+      fileName: 'app.v1'
+      filePath: '/services/app.v1.*.service'
+      config:
+        description: 'Application Service'
+
+    destroy.run('app').then ->
+      expect(fleetctl.destroy).toHaveBeenCalledWith 'app.v1.1.service'
+      expect(fleetctl.destroy.calls.length).toBe 1
+
+      done()
+
+  it 'should throw an error if the service doesn\'t exist', (done) ->
+    Destroy = proxyquire '../src/destroy',
+      './cordagefile': cordagefile
+      './fleetctl': fleetctl
+
+    destroy = new Destroy program
+
+    cordagefile.services.push
+      name: 'app'
+
+    destroy.run('database').then ->
+      expect(fleetctl.destroy).not.toHaveBeenCalled()
+      done()

--- a/test/destroy.spec.coffee
+++ b/test/destroy.spec.coffee
@@ -35,7 +35,7 @@ describe 'cordage destroy', ->
       config:
         description: 'Application Service'
 
-    destroy.run('app').then ->
+    destroy.run('app', force: true).then ->
       expect(fleetctl.destroy).toHaveBeenCalledWith 'app.v1.1.service'
       expect(fleetctl.destroy.calls.length).toBe 1
 
@@ -51,6 +51,6 @@ describe 'cordage destroy', ->
     cordagefile.services.push
       name: 'app'
 
-    destroy.run('database').then ->
+    destroy.run('database', force: true).then ->
       expect(fleetctl.destroy).not.toHaveBeenCalled()
       done()

--- a/test/mocks/program.coffee
+++ b/test/mocks/program.coffee
@@ -1,6 +1,7 @@
-program = jasmine.createSpyObj 'program', ['command', 'description', 'action']
+program = jasmine.createSpyObj 'program', ['command', 'description', 'action', 'option']
 program.command.andReturn program
 program.description.andReturn program
 program.action.andReturn program
+program.option.andReturn program
 
 module.exports = program


### PR DESCRIPTION
fixes #6 

You can now run `cordage destroy <service>` to destroy all units associated with
the given service.
