### PR TITLE
Refactor service management / service versions

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -18,7 +18,7 @@
     },
     "max_line_length": {
         "name": "max_line_length",
-        "value": 120,
+        "value": 140,
         "level": "error",
         "limitComments": true
     },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "mkdirp": "~0.5.0",
     "property-accessors": "~1.1.0",
     "q": "~1.0.1",
+    "request": "~2.36.0",
     "string": "~1.8.1",
     "swig": "~1.3.2"
   },

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -1,4 +1,5 @@
 program = require 'commander'
+config = require './config'
 
 program
 .version '0.0.1'
@@ -10,7 +11,7 @@ commands = [
 ]
 
 for Command in commands
-  new Command program
+  new Command program, config
 
 program
 .parse process.argv

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1,0 +1,2 @@
+module.exports =
+  servicesPath: "#{process.cwd()}/.cordage/services"

--- a/src/deploy.coffee
+++ b/src/deploy.coffee
@@ -40,7 +40,7 @@ class Deploy
 
         # find existing units for this service
         serviceUnits = _.filter units, (unit) ->
-          true if Service.fromUnitName(unit.unit, [ service ]) is service
+          true if Service.fromUnitName(unit.name, [ service ]) is service
 
         if serviceUnits.length > 0
           log.info service.name, "#{serviceUnits.length} unit(s) have already been deployed"

--- a/src/deploy.coffee
+++ b/src/deploy.coffee
@@ -39,8 +39,7 @@ class Deploy
       q.all cordagefile.services.map (service) ->
 
         # find existing units for this service
-        serviceUnits = _.filter units, (unit) ->
-          true if Service.fromUnitName(unit.name, [ service ]) is service
+        serviceUnits = _.filter units, (unit) -> unit.belongsTo service
 
         if serviceUnits.length > 0
           log.info service.name, "#{serviceUnits.length} unit(s) have already been deployed"

--- a/src/deploy.coffee
+++ b/src/deploy.coffee
@@ -55,7 +55,7 @@ class Deploy
       log.action 'Pushing units...'
       q.all services.map (service) ->
         q.all service.units.map (unit) ->
-          fleetctl.submit unit
+          fleetctl.submit unit.path
 
     .then ->
       log.action 'Starting services...'
@@ -63,7 +63,7 @@ class Deploy
         log.info service.name, 'Starting'
 
         q.all service.units.map (unit) ->
-          fleetctl.start unit
+          fleetctl.start unit.path
 
     .catch (err) ->
       log.error 'An error has occured whilst deploying', err.toString()

--- a/src/deploy.coffee
+++ b/src/deploy.coffee
@@ -3,12 +3,17 @@ q = require 'q'
 log = require './log'
 fleetctl = require './fleetctl'
 cordagefile = require './cordagefile'
+ServiceBuilder = require './service-builder'
+RegistryApi = require './registry-api'
 
 # Public: Builds and deploys the application to the cluster.
 module.exports =
 class Deploy
 
-  constructor: (program) ->
+  registryApi = null
+  serviceBuilder = null
+
+  constructor: (program, @config) ->
     program
     .command 'deploy'
     .description 'builds and deploys your application'
@@ -17,6 +22,9 @@ class Deploy
   # Public: Run the deploy command.
   run: =>
     services = null
+    registryApi = new RegistryApi
+    serviceBuilder = new ServiceBuilder registryApi, @config
+
     cordagefile.read()
 
     .then =>
@@ -26,13 +34,17 @@ class Deploy
     .then ->
       services = cordagefile.services
       log.action 'Pushing services...'
-      fleetctl.submit services.map (service) -> service.filePath
+      q.all services.map (service) ->
+        q.all service.instances.map (instance) ->
+          fleetctl.submit instance
 
     .then ->
       log.action 'Starting services...'
       q.all services.map (service) ->
         log.info service.name, 'Starting'
-        fleetctl.start service.filePath
+
+        q.all service.instances.map (instance) ->
+          fleetctl.start instance
 
     .catch (err) ->
       log.error 'An error has occured whilst deploying', err.toString()
@@ -41,7 +53,6 @@ class Deploy
   buildServices: ->
     log.action 'Building services...'
 
-    for service in cordagefile.services
+    q.all cordagefile.services.map (service) ->
       log.info service.name, 'Building'
-
-      service.build()
+      service.build serviceBuilder

--- a/src/deploy.coffee
+++ b/src/deploy.coffee
@@ -39,6 +39,7 @@ class Deploy
         registryApi.getLatestTagForImage service.config.image
         .then (tag) ->
           service.tag = tag
+          log.info service.name, "now at version #{tag.name}"
 
     .then ->
       log.action 'Checking for existing units...'
@@ -47,41 +48,51 @@ class Deploy
     .then (units) ->
       q.all cordagefile.services.map (service) ->
 
-        # find existing units for this service
+        # find existing units for this service with the latest version
         serviceUnits = _.filter units, (unit) -> unit.belongsTo(service) and unit.isVersion(service.tag.name)
 
         if serviceUnits.length > 0
+          # units already exist for this version, deployment probably isn't necessary
           service.unitCount = serviceUnits.length
           log.info service.name, "#{serviceUnits.length} unit(s) have already been deployed for version #{service.tag.name}"
-        else
-          log.info service.name, "No units have been deployed for version #{service.tag.name}"
 
+        else
+          # no units exist for this version
+          log.info service.name, "no units have been deployed for version #{service.tag.name}"
+
+          # find all units which are any version apart from the latest
           oldServiceUnits = _.filter units, (unit) -> unit.belongsTo(service) and not unit.isVersion(service.tag.name)
+          # group these units by version
           unitsByVersion = _.groupBy oldServiceUnits, 'version'
+          # get the highest amount of units grouped by version
           oldUnitCount = _.max(unitsByVersion, (unit, key) -> unit.length).length
 
+          # this is now how many units we should deploy for the new version
           service.unitCount = oldUnitCount
 
           if oldUnitCount > 0
             log.info service.name, "#{oldUnitCount} unit(s) already exist for a previous version"
           else
-            log.info service.name, "No units exist for any previous versions"
+            log.info service.name, "no units exist for any previous versions"
 
-        log.info service.name, "Building #{service.unitCount} unit(s)"
+        # now build x amount of units (determined above) for the service
+        log.info service.name, "building #{service.unitCount} unit(s)"
 
         service.build unitBuilder, service.tag.name
 
     .then ->
       log.action 'Pushing units...'
       q.all services.map (service) ->
+        # submit each unit for this service
         q.all service.units.map (unit) ->
           fleetctl.submit unit.path
 
     .then ->
       log.action 'Starting services...'
       q.all services.map (service) ->
-        log.info service.name, 'Starting'
+        log.info service.name, "starting #{service.units.length} unit(s)"
 
+        # start each unit for this service
         q.all service.units.map (unit) ->
           fleetctl.start unit.path
 

--- a/src/destroy.coffee
+++ b/src/destroy.coffee
@@ -34,8 +34,7 @@ class Destroy
 
     .then (units) ->
       # find only units associated with the service we want to destroy
-      _.filter units, (unit) ->
-        true if Service.fromUnitName(unit.name, [ service ]) is service
+      _.filter units, (unit) -> unit.belongsTo service
 
     .then (serviceUnits) ->
       units = serviceUnits

--- a/src/destroy.coffee
+++ b/src/destroy.coffee
@@ -35,7 +35,7 @@ class Destroy
     .then (units) ->
       # find only units associated with the service we want to destroy
       _.filter units, (unit) ->
-        true if Service.fromUnitName(unit.unit, [ service ]) is service
+        true if Service.fromUnitName(unit.name, [ service ]) is service
 
     .then (serviceUnits) ->
       units = serviceUnits
@@ -60,8 +60,8 @@ class Destroy
 
       # run `fleet destroy` for each unit
       q.all units.map (unit) ->
-        log.info string(unit.unit).chompRight('.service').toString(), 'Destroying'
-        fleetctl.destroy unit.unit
+        log.info string(unit.name).chompRight('.service').toString(), 'Destroying'
+        fleetctl.destroy unit.name
 
     .then -> log.action "#{serviceName} has been destroyed."
 

--- a/src/destroy.coffee
+++ b/src/destroy.coffee
@@ -59,7 +59,7 @@ class Destroy
 
       # run `fleet destroy` for each unit
       q.all units.map (unit) ->
-        log.info string(unit.name).chompRight('.service').toString(), 'Destroying'
+        log.info string(unit.name).chompRight('.service').toString(), 'destroying'
         fleetctl.destroy unit.name
 
     .then -> log.action "#{serviceName} has been destroyed."

--- a/src/fleetctl.coffee
+++ b/src/fleetctl.coffee
@@ -1,13 +1,20 @@
 q = require 'q'
 fleetctl = require('fleetctl')()
 
+Unit = require './unit'
+
 module.exports =
   # Public: Run `fleetctl list-units`
   listUnits: ->
     deferred = q.defer()
 
-    fleetctl.list_units (err, units) ->
+    fleetctl.list_units (err, fleetUnits) ->
       deferred.reject err if err
+
+      units = []
+      for fleetUnit in fleetUnits
+        units.push new Unit fleetUnit.unit, fleetUnit
+
       deferred.resolve units unless err
 
     return deferred.promise

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -1,6 +1,7 @@
 Table = require 'cli-table'
 chalk = require 'chalk'
 string = require 'string'
+_ = require 'lodash'
 
 log = require './log'
 fleetctl = require './fleetctl'
@@ -32,7 +33,7 @@ class List
 
         # create and populate table
         table = @createUnitTable()
-        table.populate service, units
+        table.populate _.filter units, (unit) -> unit.belongsTo service
 
         console.log table.toString()
 
@@ -50,16 +51,13 @@ class List
         compact: true
 
     # Populate the table with units
-    table.populate = (service, units) ->
+    table.populate = (units) ->
       for unit in units
-        unitService = Service.fromUnitName unit.name, cordagefile.services
-
-        if unitService is service
-          table.push [
-            string(unit.name).chompRight('.service').toString()
-            unit.state
-            unit.active or '-'
-            unit.ip or '-'
-          ]
+        table.push [
+          string(unit.name).chompRight('.service').toString()
+          unit.state
+          unit.active or '-'
+          unit.ip or '-'
+        ]
 
     return table

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -52,11 +52,11 @@ class List
     # Populate the table with units
     table.populate = (service, units) ->
       for unit in units
-        unitService = Service.fromUnitName unit.unit, cordagefile.services
+        unitService = Service.fromUnitName unit.name, cordagefile.services
 
         if unitService is service
           table.push [
-            string(unit.unit).chompRight('.service').toString()
+            string(unit.name).chompRight('.service').toString()
             unit.state
             unit.active or '-'
             unit.ip or '-'

--- a/src/registry-api.coffee
+++ b/src/registry-api.coffee
@@ -23,11 +23,16 @@ class RegistryApi
     q.promise (resolve, reject) =>
       request.get "#{@endpoint}/v1/repositories/#{image}/tags", json: true, wrapPromise resolve, reject
     .then (layers) ->
+      # find a layer called 'latest'
       latest = _.find layers, name: 'latest'
+
+      # find the layer which has the same image ID as the 'latest' tag.
+      # this layer should have the name of the latest version.
       latestTag = _.find layers, (layer) ->
         true if layer.layer is latest.layer and layer.name isnt 'latest'
 
       return latestTag
+
     .catch (error) ->
       if error is 404
         throw new Error "Unknown image \"#{image}\". The image must exist in the registry."

--- a/src/registry-api.coffee
+++ b/src/registry-api.coffee
@@ -1,0 +1,35 @@
+q = require 'q'
+_ = require 'lodash'
+request = require 'request'
+
+# Private: Wraps request styled callback in a deferred-calling function
+wrapPromise = (resolve, reject) ->
+  (error, response, body) ->
+    if error
+      reject error
+      return
+    if "#{response.statusCode}".substring(0, 1) == '4'
+      reject response.statusCode
+      return
+    resolve body
+
+# Public: Docker Registry API Abstraction
+module.exports =
+class RegistryApi
+
+  constructor: (@endpoint = 'https://registry.hub.docker.com') ->
+
+  getLatestTagForImage: (image) ->
+    q.promise (resolve, reject) =>
+      request.get "#{@endpoint}/v1/repositories/#{image}/tags", json: true, wrapPromise resolve, reject
+    .then (layers) ->
+      latest = _.find layers, name: 'latest'
+      latestTag = _.find layers, (layer) ->
+        true if layer.layer is latest.layer and layer.name isnt 'latest'
+
+      return latestTag
+    .catch (error) ->
+      if error is 404
+        throw new Error "Unknown image \"#{image}\". The image must exist in the registry."
+      else
+        throw error

--- a/src/service.coffee
+++ b/src/service.coffee
@@ -23,7 +23,7 @@ class Service
       _unitCount = value
 
   # Public: Builds unit files for this service.
-  build: (unitBuilder) =>
+  build: (unitBuilder, version) =>
     q.all [1..@unitCount].map (index) =>
-      unitBuilder.build this, index
+      unitBuilder.build this, version, index
     .then (@units) =>

--- a/src/service.coffee
+++ b/src/service.coffee
@@ -2,14 +2,14 @@ string = require 'string'
 q = require 'q'
 PropertyAccessors = require 'property-accessors'
 
-# Public: Represents a single Service.
+# Public: Represents a single service.
 module.exports =
 class Service
   PropertyAccessors.includeInto this
 
   _unitCount = 0
 
-  # Public: Contains the file paths for any generated unit files.
+  # Public: Contains the units associated with this service.
   units: []
 
   constructor: (@name, @config) ->

--- a/src/service.coffee
+++ b/src/service.coffee
@@ -1,22 +1,34 @@
 string = require 'string'
 q = require 'q'
+PropertyAccessors = require 'property-accessors'
 
 # Public: Represents a single Service.
 module.exports =
 class Service
+  PropertyAccessors.includeInto this
 
-  instances: []
+  _unitCount = 0
+
+  # Public: Contains the file paths for any generated unit files.
+  units: []
 
   constructor: (@name, @config) ->
-    @instanceCount = 1 # TODO scaling
+    @minUnits = @config.minUnits or 1
 
-  # Public: Builds serviced files for this service.
-  build: (serviceBuilder) =>
-    q.all [1..@instanceCount].map (index) =>
-      serviceBuilder.build this, index
-    .then (@instances) =>
+  # Public: Indicates how many units there should be for this service.
+  @::accessor 'unitCount',
+    get: ->
+      if _unitCount > @minUnits then _unitCount else @minUnits
+    set: (value) ->
+      _unitCount = value
 
-  # Public: Creates a new Service instance from the given fleet unit name.
+  # Public: Builds unit files for this service.
+  build: (unitBuilder) =>
+    q.all [1..@unitCount].map (index) =>
+      unitBuilder.build this, index
+    .then (@units) =>
+
+  # Public: Creates a new Service instance from the given unit name.
   @fromUnitName = (unitName, services) ->
     for service in services
       if string(unitName).startsWith "#{service.name}.v"

--- a/src/service.coffee
+++ b/src/service.coffee
@@ -13,7 +13,7 @@ class Service
   units: []
 
   constructor: (@name, @config) ->
-    @minUnits = @config.minUnits or 1
+    @minUnits = @config?.minUnits or 1
 
   # Public: Indicates how many units there should be for this service.
   @::accessor 'unitCount',

--- a/src/service.coffee
+++ b/src/service.coffee
@@ -27,9 +27,3 @@ class Service
     q.all [1..@unitCount].map (index) =>
       unitBuilder.build this, index
     .then (@units) =>
-
-  # Public: Creates a new Service instance from the given unit name.
-  @fromUnitName = (unitName, services) ->
-    for service in services
-      if string(unitName).startsWith "#{service.name}.v"
-        return service

--- a/src/service.coffee
+++ b/src/service.coffee
@@ -1,23 +1,23 @@
 string = require 'string'
-
-serviceBuilder = require './service-builder'
+q = require 'q'
 
 # Public: Represents a single Service.
 module.exports =
 class Service
 
+  instances: []
+
   constructor: (@name, @config) ->
-    @version = 'v1' # TODO generate somehow
     @instanceCount = 1 # TODO scaling
-    @fileName = "#{@name}.#{@version}"
-    @filePath = "#{serviceBuilder.servicesPath}/#{@fileName}.*.service"
 
   # Public: Builds serviced files for this service.
-  build: ->
-    serviceBuilder this, index for index in [1..@instanceCount]
+  build: (serviceBuilder) =>
+    q.all [1..@instanceCount].map (index) =>
+      serviceBuilder.build this, index
+    .then (@instances) =>
 
   # Public: Creates a new Service instance from the given fleet unit name.
   @fromUnitName = (unitName, services) ->
     for service in services
-      if string(unitName).startsWith service.fileName
+      if string(unitName).startsWith "#{service.name}.v"
         return service

--- a/src/unit-builder.coffee
+++ b/src/unit-builder.coffee
@@ -4,6 +4,8 @@ swig = require 'swig'
 mkdirp = require 'mkdirp'
 _ = require 'lodash'
 
+Unit = require './unit'
+
 resourcesPath = path.resolve "#{__dirname}/../resources"
 
 templates =
@@ -44,4 +46,4 @@ class UnitBuilder
       mkdirp.sync @config.servicesPath
       fs.writeFileSync filePath, output
 
-      return filePath
+      return new Unit filePath

--- a/src/unit-builder.coffee
+++ b/src/unit-builder.coffee
@@ -9,13 +9,13 @@ resourcesPath = path.resolve "#{__dirname}/../resources"
 templates =
   service: swig.compileFile "#{resourcesPath}/service.tmpl"
 
-# Public: Generates service files.
+# Public: Generates unit files.
 module.exports =
-class ServiceBuilder
+class UnitBuilder
 
   constructor: (@registryApi, @config) ->
 
-  # Public: Generates a serviced file for the given service.
+  # Public: Generates a unit file for the given service.
   build: (service, instance) =>
     @registryApi.getLatestTagForImage service.config.image
     .then (tag) =>

--- a/src/unit-builder.coffee
+++ b/src/unit-builder.coffee
@@ -46,4 +46,7 @@ class UnitBuilder
       mkdirp.sync @config.servicesPath
       fs.writeFileSync filePath, output
 
-      return new Unit filePath
+      unit = new Unit filePath
+      unit.service = service
+
+      return unit

--- a/src/unit.coffee
+++ b/src/unit.coffee
@@ -5,8 +5,10 @@ string = require 'string'
 module.exports =
 class Unit
 
-  constructor: (pathOrName) ->
+  constructor: (pathOrName, state) ->
     @name = path.basename pathOrName
 
     if string(pathOrName).startsWith '/' or string(pathOrName).startsWith '.'
       @path = pathOrName
+
+    {@state, @active, @ip} = state if state?

--- a/src/unit.coffee
+++ b/src/unit.coffee
@@ -11,9 +11,9 @@ class Unit
     nameParts = @name.split '.'
     @serviceName = nameParts[0]
     @version = string(nameParts[1]).chompLeft('v').toString()
-    @instance = nameParts[2]
+    @instance = parseInt nameParts[2]
 
-    if string(pathOrName).startsWith '/' or string(pathOrName).startsWith '.'
+    if string(pathOrName).startsWith('/') or string(pathOrName).startsWith('.')
       @path = pathOrName
 
     {@state, @active, @ip} = state if state?

--- a/src/unit.coffee
+++ b/src/unit.coffee
@@ -12,3 +12,7 @@ class Unit
       @path = pathOrName
 
     {@state, @active, @ip} = state if state?
+
+  # Public: Indicates whether this unit belongs to the given service.
+  belongsTo: (service) =>
+    string(@name).startsWith "#{service.name}.v"

--- a/src/unit.coffee
+++ b/src/unit.coffee
@@ -8,11 +8,13 @@ class Unit
   constructor: (pathOrName, state) ->
     @name = path.basename pathOrName
 
+    # parse the name and get information like service name, version and instance
     nameParts = @name.split '.'
     @serviceName = nameParts[0]
     @version = string(nameParts[1]).chompLeft('v').toString()
     @instance = parseInt nameParts[2]
 
+    # check if name is a path
     if string(pathOrName).startsWith('/') or string(pathOrName).startsWith('.')
       @path = pathOrName
 

--- a/src/unit.coffee
+++ b/src/unit.coffee
@@ -8,6 +8,11 @@ class Unit
   constructor: (pathOrName, state) ->
     @name = path.basename pathOrName
 
+    nameParts = @name.split '.'
+    @serviceName = nameParts[0]
+    @version = string(nameParts[1]).chompLeft('v').toString()
+    @instance = nameParts[2]
+
     if string(pathOrName).startsWith '/' or string(pathOrName).startsWith '.'
       @path = pathOrName
 
@@ -16,3 +21,7 @@ class Unit
   # Public: Indicates whether this unit belongs to the given service.
   belongsTo: (service) =>
     string(@name).startsWith "#{service.name}.v"
+
+  # Public: Indicates whether the given version identifier is the same as the given version.
+  isVersion: (version) =>
+    version.replace(/\./g, '-') is @version

--- a/src/unit.coffee
+++ b/src/unit.coffee
@@ -1,0 +1,12 @@
+path = require 'path'
+string = require 'string'
+
+# Public: Represents a fleet unit associated with a cordage service.
+module.exports =
+class Unit
+
+  constructor: (pathOrName) ->
+    @name = path.basename pathOrName
+
+    if string(pathOrName).startsWith '/' or string(pathOrName).startsWith '.'
+      @path = pathOrName

--- a/test/deploy.spec.coffee
+++ b/test/deploy.spec.coffee
@@ -1,9 +1,12 @@
 proxyquire = require 'proxyquire'
 q = require 'q'
 
+Service = require '../src/service'
+
 program = null
 cordagefile = null
 fleetctl = null
+unitBuilder = null
 
 describe 'cordage deploy', ->
 
@@ -14,40 +17,34 @@ describe 'cordage deploy', ->
       read: -> q {}
       services: []
 
-    fleetctl = jasmine.createSpyObj 'fleetctl', ['submit', 'start']
+    fleetctl = jasmine.createSpyObj 'fleetctl', ['submit', 'start', 'listUnits']
+    unitBuilder = jasmine.createSpyObj 'unitBuilder', ['build']
 
   it 'should build service files and then submit and start them using fleet', (done) ->
     Deploy = proxyquire '../src/deploy',
       './cordagefile': cordagefile
       './fleetctl': fleetctl
+      './unit-builder': -> unitBuilder
 
     deploy = new Deploy program
-    buildCallback = jasmine.createSpy 'build'
 
-    cordagefile.services.push
-      name: 'test'
-      fileName: 'test.v0-0-1'
-      config:
-        description: 'Testing Service'
-      units: [
-        '/services/test.v0-0-1.1.service'
-      ]
-      build: buildCallback
+    fleetctl.listUnits.andReturn q([])
 
-    cordagefile.services.push
-      name: 'app'
-      fileName: 'app.v0-0-1'
-      config:
-        description: 'Application Service'
-      units: [
-        '/services/app.v0-0-1.1.service'
-        '/services/app.v0-0-1.2.service'
-      ]
-      build: buildCallback
+    test = new Service 'test', description: 'Testing Service'
+    cordagefile.services.push test
+
+    app = new Service 'app', description: 'Application Service', minUnits: 2
+    cordagefile.services.push app
+
+    buildUnits = [
+      '/services/test.v0-0-1.1.service'
+      '/services/app.v0-0-1.1.service'
+      '/services/app.v0-0-1.2.service'
+    ]
+    currentBuildUnit = 0
+    unitBuilder.build.andCallFake -> q(buildUnits[currentBuildUnit++])
 
     deploy.run().then ->
-      expect(buildCallback).toHaveBeenCalled()
-
       expect(fleetctl.submit).toHaveBeenCalledWith '/services/test.v0-0-1.1.service'
       expect(fleetctl.start).toHaveBeenCalledWith '/services/test.v0-0-1.1.service'
 
@@ -59,5 +56,40 @@ describe 'cordage deploy', ->
 
       expect(fleetctl.submit.calls.length).toBe 3
       expect(fleetctl.start.calls.length).toBe 3
+
+      done()
+
+  it 'should deploy the same amount of units as the old version when deploying a new version', (done) ->
+    Deploy = proxyquire '../src/deploy',
+      './cordagefile': cordagefile
+      './fleetctl': fleetctl
+      './unit-builder': -> unitBuilder
+
+    deploy = new Deploy program
+
+    fleetctl.listUnits.andReturn q([
+      { unit: 'app.v0-0-1.1.service', state: 'activated', active: 'running', ip: '127.0.0.1' }
+      { unit: 'app.v0-0-1.2.service', state: 'activated', active: 'running', ip: '127.0.0.2' }
+    ])
+
+    app = new Service 'app', description: 'Application Service'
+    cordagefile.services.push app
+
+    buildUnits = [
+      '/services/app.v0-0-2.1.service'
+      '/services/app.v0-0-2.2.service'
+    ]
+    currentBuildUnit = 0
+    unitBuilder.build.andCallFake -> q(buildUnits[currentBuildUnit++])
+
+    deploy.run().then ->
+      expect(fleetctl.submit).toHaveBeenCalledWith '/services/app.v0-0-2.1.service'
+      expect(fleetctl.start).toHaveBeenCalledWith '/services/app.v0-0-2.1.service'
+
+      expect(fleetctl.submit).toHaveBeenCalledWith '/services/app.v0-0-2.2.service'
+      expect(fleetctl.start).toHaveBeenCalledWith '/services/app.v0-0-2.2.service'
+
+      expect(fleetctl.submit.calls.length).toBe 2
+      expect(fleetctl.start.calls.length).toBe 2
 
       done()

--- a/test/deploy.spec.coffee
+++ b/test/deploy.spec.coffee
@@ -31,6 +31,9 @@ describe 'cordage deploy', ->
       filePath: '/services/test.v1.*.service'
       config:
         description: 'Testing Service'
+      instances: [
+        '/services/test.v1.*.service'
+      ]
       build: buildCallback
 
     cordagefile.services.push
@@ -39,15 +42,16 @@ describe 'cordage deploy', ->
       filePath: '/services/app.v1.*.service'
       config:
         description: 'Application Service'
+      instances: [
+        '/services/app.v1.*.service'
+      ]
       build: buildCallback
 
     deploy.run().then ->
       expect(buildCallback).toHaveBeenCalled()
 
-      expect(fleetctl.submit).toHaveBeenCalledWith [
-        '/services/test.v1.*.service'
-        '/services/app.v1.*.service'
-      ]
+      expect(fleetctl.submit).toHaveBeenCalledWith '/services/test.v1.*.service'
+      expect(fleetctl.submit).toHaveBeenCalledWith '/services/app.v1.*.service'
       expect(fleetctl.start).toHaveBeenCalledWith '/services/test.v1.*.service'
       expect(fleetctl.start).toHaveBeenCalledWith '/services/app.v1.*.service'
 

--- a/test/deploy.spec.coffee
+++ b/test/deploy.spec.coffee
@@ -2,6 +2,7 @@ proxyquire = require 'proxyquire'
 q = require 'q'
 
 Service = require '../src/service'
+Unit = require '../src/unit'
 
 program = null
 cordagefile = null
@@ -36,13 +37,13 @@ describe 'cordage deploy', ->
     app = new Service 'app', description: 'Application Service', minUnits: 2
     cordagefile.services.push app
 
-    buildUnits = [
-      '/services/test.v0-0-1.1.service'
-      '/services/app.v0-0-1.1.service'
-      '/services/app.v0-0-1.2.service'
+    units = [
+      new Unit '/services/test.v0-0-1.1.service'
+      new Unit '/services/app.v0-0-1.1.service'
+      new Unit '/services/app.v0-0-1.2.service'
     ]
-    currentBuildUnit = 0
-    unitBuilder.build.andCallFake -> q(buildUnits[currentBuildUnit++])
+    currentUnit = 0
+    unitBuilder.build.andCallFake -> q(units[currentUnit++])
 
     deploy.run().then ->
       expect(fleetctl.submit).toHaveBeenCalledWith '/services/test.v0-0-1.1.service'
@@ -75,12 +76,12 @@ describe 'cordage deploy', ->
     app = new Service 'app', description: 'Application Service'
     cordagefile.services.push app
 
-    buildUnits = [
-      '/services/app.v0-0-2.1.service'
-      '/services/app.v0-0-2.2.service'
+    units = [
+      new Unit '/services/app.v0-0-2.1.service'
+      new Unit '/services/app.v0-0-2.2.service'
     ]
-    currentBuildUnit = 0
-    unitBuilder.build.andCallFake -> q(buildUnits[currentBuildUnit++])
+    currentUnit = 0
+    unitBuilder.build.andCallFake -> q(units[currentUnit++])
 
     deploy.run().then ->
       expect(fleetctl.submit).toHaveBeenCalledWith '/services/app.v0-0-2.1.service'

--- a/test/deploy.spec.coffee
+++ b/test/deploy.spec.coffee
@@ -69,8 +69,8 @@ describe 'cordage deploy', ->
     deploy = new Deploy program
 
     fleetctl.listUnits.andReturn q([
-      { unit: 'app.v0-0-1.1.service', state: 'activated', active: 'running', ip: '127.0.0.1' }
-      { unit: 'app.v0-0-1.2.service', state: 'activated', active: 'running', ip: '127.0.0.2' }
+      new Unit 'app.v0-0-1.1.service', state: 'activated', active: 'running', ip: '127.0.0.1'
+      new Unit 'app.v0-0-1.2.service', state: 'activated', active: 'running', ip: '127.0.0.2'
     ])
 
     app = new Service 'app', description: 'Application Service'

--- a/test/deploy.spec.coffee
+++ b/test/deploy.spec.coffee
@@ -4,10 +4,12 @@ q = require 'q'
 Service = require '../src/service'
 Unit = require '../src/unit'
 
+deploy = null
 program = null
 cordagefile = null
 fleetctl = null
 unitBuilder = null
+registryApi = null
 
 describe 'cordage deploy', ->
 
@@ -18,17 +20,20 @@ describe 'cordage deploy', ->
       read: -> q {}
       services: []
 
+    registryApi =
+      getLatestTagForImage: -> q name: '0.0.1'
     fleetctl = jasmine.createSpyObj 'fleetctl', ['submit', 'start', 'listUnits']
     unitBuilder = jasmine.createSpyObj 'unitBuilder', ['build']
 
-  it 'should build service files and then submit and start them using fleet', (done) ->
     Deploy = proxyquire '../src/deploy',
       './cordagefile': cordagefile
       './fleetctl': fleetctl
       './unit-builder': -> unitBuilder
+      './registry-api': -> registryApi
 
     deploy = new Deploy program
 
+  it 'should build service files and then submit and start them using fleet', (done) ->
     fleetctl.listUnits.andReturn q([])
 
     test = new Service 'test', description: 'Testing Service'
@@ -61,24 +66,52 @@ describe 'cordage deploy', ->
       done()
 
   it 'should deploy the same amount of units as the old version when deploying a new version', (done) ->
-    Deploy = proxyquire '../src/deploy',
-      './cordagefile': cordagefile
-      './fleetctl': fleetctl
-      './unit-builder': -> unitBuilder
-
-    deploy = new Deploy program
-
     fleetctl.listUnits.andReturn q([
       new Unit 'app.v0-0-1.1.service', state: 'activated', active: 'running', ip: '127.0.0.1'
-      new Unit 'app.v0-0-1.2.service', state: 'activated', active: 'running', ip: '127.0.0.2'
+      new Unit 'app.v0-0-2.1.service', state: 'activated', active: 'running', ip: '127.0.0.1'
+      new Unit 'app.v0-0-2.2.service', state: 'activated', active: 'running', ip: '127.0.0.2'
     ])
 
-    app = new Service 'app', description: 'Application Service'
+    registryApi.getLatestTagForImage = -> q name: '0.0.3'
+
+    app = new Service 'app', description: 'Application Service', minUnits: 1
+    cordagefile.services.push app
+
+    units = [
+      new Unit '/services/app.v0-0-3.1.service'
+      new Unit '/services/app.v0-0-3.2.service'
+    ]
+    currentUnit = 0
+    unitBuilder.build.andCallFake -> q(units[currentUnit++])
+
+    deploy.run().then ->
+      expect(fleetctl.submit).toHaveBeenCalledWith '/services/app.v0-0-3.1.service'
+      expect(fleetctl.start).toHaveBeenCalledWith '/services/app.v0-0-3.1.service'
+
+      expect(fleetctl.submit).toHaveBeenCalledWith '/services/app.v0-0-3.2.service'
+      expect(fleetctl.start).toHaveBeenCalledWith '/services/app.v0-0-3.2.service'
+
+      expect(fleetctl.submit.calls.length).toBe 2
+      expect(fleetctl.start.calls.length).toBe 2
+
+      done()
+
+  it 'should deploy the same amount of units when deploying the same version', (done) ->
+    fleetctl.listUnits.andReturn q([
+      new Unit 'app.v0-0-2.1.service', state: 'activated', active: 'running', ip: '127.0.0.1'
+      new Unit 'app.v0-0-2.2.service', state: 'activated', active: 'running', ip: '127.0.0.2'
+      new Unit 'app.v0-0-2.3.service', state: 'activated', active: 'running', ip: '127.0.0.2'
+    ])
+
+    registryApi.getLatestTagForImage = -> q name: '0.0.2'
+
+    app = new Service 'app', description: 'Application Service', minUnits: 2
     cordagefile.services.push app
 
     units = [
       new Unit '/services/app.v0-0-2.1.service'
       new Unit '/services/app.v0-0-2.2.service'
+      new Unit '/services/app.v0-0-2.3.service'
     ]
     currentUnit = 0
     unitBuilder.build.andCallFake -> q(units[currentUnit++])
@@ -90,7 +123,10 @@ describe 'cordage deploy', ->
       expect(fleetctl.submit).toHaveBeenCalledWith '/services/app.v0-0-2.2.service'
       expect(fleetctl.start).toHaveBeenCalledWith '/services/app.v0-0-2.2.service'
 
-      expect(fleetctl.submit.calls.length).toBe 2
-      expect(fleetctl.start.calls.length).toBe 2
+      expect(fleetctl.submit).toHaveBeenCalledWith '/services/app.v0-0-2.3.service'
+      expect(fleetctl.start).toHaveBeenCalledWith '/services/app.v0-0-2.3.service'
+
+      expect(fleetctl.submit.calls.length).toBe 3
+      expect(fleetctl.start.calls.length).toBe 3
 
       done()

--- a/test/deploy.spec.coffee
+++ b/test/deploy.spec.coffee
@@ -22,37 +22,42 @@ describe 'cordage deploy', ->
       './fleetctl': fleetctl
 
     deploy = new Deploy program
-
     buildCallback = jasmine.createSpy 'build'
 
     cordagefile.services.push
       name: 'test'
-      fileName: 'test.v1'
-      filePath: '/services/test.v1.*.service'
+      fileName: 'test.v0-0-1'
       config:
         description: 'Testing Service'
-      instances: [
-        '/services/test.v1.*.service'
+      units: [
+        '/services/test.v0-0-1.1.service'
       ]
       build: buildCallback
 
     cordagefile.services.push
       name: 'app'
-      fileName: 'app.v1'
-      filePath: '/services/app.v1.*.service'
+      fileName: 'app.v0-0-1'
       config:
         description: 'Application Service'
-      instances: [
-        '/services/app.v1.*.service'
+      units: [
+        '/services/app.v0-0-1.1.service'
+        '/services/app.v0-0-1.2.service'
       ]
       build: buildCallback
 
     deploy.run().then ->
       expect(buildCallback).toHaveBeenCalled()
 
-      expect(fleetctl.submit).toHaveBeenCalledWith '/services/test.v1.*.service'
-      expect(fleetctl.submit).toHaveBeenCalledWith '/services/app.v1.*.service'
-      expect(fleetctl.start).toHaveBeenCalledWith '/services/test.v1.*.service'
-      expect(fleetctl.start).toHaveBeenCalledWith '/services/app.v1.*.service'
+      expect(fleetctl.submit).toHaveBeenCalledWith '/services/test.v0-0-1.1.service'
+      expect(fleetctl.start).toHaveBeenCalledWith '/services/test.v0-0-1.1.service'
+
+      expect(fleetctl.submit).toHaveBeenCalledWith '/services/app.v0-0-1.1.service'
+      expect(fleetctl.start).toHaveBeenCalledWith '/services/app.v0-0-1.1.service'
+
+      expect(fleetctl.submit).toHaveBeenCalledWith '/services/app.v0-0-1.2.service'
+      expect(fleetctl.start).toHaveBeenCalledWith '/services/app.v0-0-1.2.service'
+
+      expect(fleetctl.submit.calls.length).toBe 3
+      expect(fleetctl.start.calls.length).toBe 3
 
       done()

--- a/test/destroy.spec.coffee
+++ b/test/destroy.spec.coffee
@@ -1,6 +1,8 @@
 proxyquire = require 'proxyquire'
 q = require 'q'
 
+Unit = require '../src/unit'
+
 program = null
 cordagefile = null
 fleetctl = null
@@ -24,8 +26,8 @@ describe 'cordage destroy', ->
     destroy = new Destroy program
 
     fleetctl.listUnits.andReturn q([
-      { unit: 'test.v1.1.service', state: 'activated', active: 'running', ip: '127.0.0.1' }
-      { unit: 'app.v1.1.service', state: 'activated', active: 'failed', ip: '127.0.0.2' }
+      new Unit 'test.v1.1.service', state: 'activated', active: 'running', ip: '127.0.0.1'
+      new Unit 'app.v1.1.service', state: 'activated', active: 'failed', ip: '127.0.0.2'
     ])
 
     cordagefile.services.push

--- a/test/list.spec.coffee
+++ b/test/list.spec.coffee
@@ -1,6 +1,8 @@
 proxyquire = require 'proxyquire'
 q = require 'q'
 
+Unit = require '../src/unit'
+
 program = null
 cordagefile = null
 fleetctl = null
@@ -27,9 +29,9 @@ describe 'cordage list', ->
     list = new List program
 
     fleetctl.listUnits.andReturn q([
-      { unit: 'test.v1.1.service', state: 'activated', active: 'running', ip: '127.0.0.1' }
-      { unit: 'test.v1.2.service', state: 'activated', active: 'running', ip: '127.0.0.1' }
-      { unit: 'test.v1.3.service', state: 'inactive', active: null, ip: null }
+      new Unit 'test.v1.1.service', state: 'activated', active: 'running', ip: '127.0.0.1'
+      new Unit 'test.v1.2.service', state: 'activated', active: 'running', ip: '127.0.0.1'
+      new Unit 'test.v1.3.service', state: 'inactive', active: null, ip: null
     ])
 
     cordagefile.services.push

--- a/test/service.spec.coffee
+++ b/test/service.spec.coffee
@@ -2,7 +2,7 @@ describe 'service', ->
 
   describe 'build', ->
     it 'should call the service builder', ->
-      serviceBuilder = jasmine.createSpyObj 'serviceBuilder', ['build']
+      unitBuilder = jasmine.createSpyObj 'unitBuilder', ['build']
 
       Service = require '../src/service'
 
@@ -11,6 +11,6 @@ describe 'service', ->
 
       registryApi = jasmine.createSpyObj 'registryApi', ['get']
 
-      service.build serviceBuilder, registryApi
+      service.build unitBuilder, registryApi
 
-      expect(serviceBuilder.build).toHaveBeenCalledWith service, 1
+      expect(unitBuilder.build).toHaveBeenCalledWith service, 1

--- a/test/service.spec.coffee
+++ b/test/service.spec.coffee
@@ -1,10 +1,37 @@
+Service = require '../src/service'
+
 describe 'service', ->
+
+  it 'should should set config options on the service instance', ->
+    service = new Service 'app',
+      minUnits: 2
+
+    expect(service.minUnits).toBe 2
+
+  describe 'unitCount', ->
+    it 'should return the minimum units if there is no unit count specified', ->
+      service = new Service 'app',
+        minUnits: 3
+
+      expect(service.unitCount).toBe 3
+
+    it 'should return the minimum units of the specified unit count is below the minimum', ->
+      service = new Service 'app',
+        minUnits: 2
+
+      service.unitCount = 1
+      expect(service.unitCount).toBe 2
+
+    it 'should return the specified unit count is it is greater than the minimum units', ->
+      service = new Service 'app',
+        minUnits: 2
+
+      service.unitCount = 3
+      expect(service.unitCount).toBe 3
 
   describe 'build', ->
     it 'should call the service builder', ->
       unitBuilder = jasmine.createSpyObj 'unitBuilder', ['build']
-
-      Service = require '../src/service'
 
       service = new Service 'app',
         description: 'Super awesome application'

--- a/test/service.spec.coffee
+++ b/test/service.spec.coffee
@@ -9,6 +9,6 @@ describe 'service', ->
       service = new Service 'app',
         description: 'Super awesome application'
 
-      service.build unitBuilder
+      service.build unitBuilder, '14.04'
 
-      expect(unitBuilder.build).toHaveBeenCalledWith service, 1
+      expect(unitBuilder.build).toHaveBeenCalledWith service, '14.04', 1

--- a/test/service.spec.coffee
+++ b/test/service.spec.coffee
@@ -9,8 +9,6 @@ describe 'service', ->
       service = new Service 'app',
         description: 'Super awesome application'
 
-      registryApi = jasmine.createSpyObj 'registryApi', ['get']
-
-      service.build unitBuilder, registryApi
+      service.build unitBuilder
 
       expect(unitBuilder.build).toHaveBeenCalledWith service, 1

--- a/test/service.spec.coffee
+++ b/test/service.spec.coffee
@@ -1,17 +1,16 @@
-proxyquire = require 'proxyquire'
-
 describe 'service', ->
 
   describe 'build', ->
     it 'should call the service builder', ->
-      serviceBuilder = jasmine.createSpy 'serviceBuilder'
+      serviceBuilder = jasmine.createSpyObj 'serviceBuilder', ['build']
 
-      Service = proxyquire '../src/service',
-        './service-builder': serviceBuilder
+      Service = require '../src/service'
 
       service = new Service 'app',
         description: 'Super awesome application'
 
-      service.build()
+      registryApi = jasmine.createSpyObj 'registryApi', ['get']
 
-      expect(serviceBuilder).toHaveBeenCalledWith service, 1
+      service.build serviceBuilder, registryApi
+
+      expect(serviceBuilder.build).toHaveBeenCalledWith service, 1

--- a/test/unit-builder.spec.coffee
+++ b/test/unit-builder.spec.coffee
@@ -8,8 +8,7 @@ describe 'unit builder', ->
       fs = jasmine.createSpyObj 'fs', ['writeFileSync']
       mkdirp = jasmine.createSpyObj 'mkdirp', ['sync']
       swig = jasmine.createSpyObj 'swig', ['compileFile']
-      registryApi =
-        getLatestTagForImage: -> q name: '14.04'
+
       config =
         servicesPath: '/tmp/services'
 
@@ -26,8 +25,8 @@ describe 'unit builder', ->
         name: 'app'
         config: {}
 
-      builder = new UnitBuilder registryApi, config
-      builder.build service, 1
+      builder = new UnitBuilder config
+      builder.build service, '14.04', 1
       .then ->
         expect(fs.writeFileSync).toHaveBeenCalledWith(
           "/tmp/services/app.v14-04.1.service", 'template contents'

--- a/test/unit-builder.spec.coffee
+++ b/test/unit-builder.spec.coffee
@@ -1,10 +1,10 @@
 q = require 'q'
 proxyquire = require 'proxyquire'
 
-describe 'service builder', ->
+describe 'unit builder', ->
 
   describe 'build', ->
-    it 'should generate a service file using the config', (done) ->
+    it 'should generate a unit file using the config', (done) ->
       fs = jasmine.createSpyObj 'fs', ['writeFileSync']
       mkdirp = jasmine.createSpyObj 'mkdirp', ['sync']
       swig = jasmine.createSpyObj 'swig', ['compileFile']
@@ -16,7 +16,7 @@ describe 'service builder', ->
       swig.compileFile.andReturn ->
         'template contents'
 
-      ServiceBuilder = proxyquire '../src/service-builder',
+      UnitBuilder = proxyquire '../src/unit-builder',
         'fs': fs
         'mkdirp': mkdirp
         'swig': swig
@@ -26,7 +26,7 @@ describe 'service builder', ->
         name: 'app'
         config: {}
 
-      builder = new ServiceBuilder registryApi, config
+      builder = new UnitBuilder registryApi, config
       builder.build service, 1
       .then ->
         expect(fs.writeFileSync).toHaveBeenCalledWith(

--- a/test/unit.spec.coffee
+++ b/test/unit.spec.coffee
@@ -1,0 +1,54 @@
+Unit = require '../src/unit'
+Service = require '../src/service'
+
+describe 'unit', ->
+
+  it 'should parse the name passed to the constructor', ->
+    unit = new Unit 'app.v14-04.1'
+
+    expect(unit.serviceName).toBe 'app'
+    expect(unit.version).toBe '14-04'
+    expect(unit.instance).toBe 1
+    expect(unit.path).toBeUndefined()
+
+  it 'should parse the state passed to the constructor', ->
+    unit = new Unit 'app.v14-04.1',
+      state: 'active'
+      active: 'running'
+      ip: '127.0.0.1'
+
+    expect(unit.state).toBe 'active'
+    expect(unit.active).toBe 'running'
+    expect(unit.ip).toBe '127.0.0.1'
+
+  it 'should parse the path passed to the constructor', ->
+    unit = new Unit './.cordage/services/app.v14-04.1.service'
+
+    expect(unit.serviceName).toBe 'app'
+    expect(unit.version).toBe '14-04'
+    expect(unit.instance).toBe 1
+    expect(unit.path).toBe './.cordage/services/app.v14-04.1.service'
+
+  describe 'belongsTo', ->
+    it 'should return true if the unit belongs to the given service', ->
+      unit = new Unit 'app.v14-04.1'
+      service = new Service 'app'
+
+      expect(unit.belongsTo service).toBe true
+
+    it 'should return false if the unit doesn\'t belong to the given service', ->
+      unit = new Unit 'app.v14-04.1'
+      service = new Service 'worker'
+
+      expect(unit.belongsTo service).toBe false
+
+  describe 'isVersion', ->
+    it 'should return true if the unit is the same version as the given version', ->
+      unit = new Unit 'app.v14-04.1'
+
+      expect(unit.isVersion '14.04').toBe true
+
+    it 'should return false if the unit isn\'t the same version as the given version', ->
+      unit = new Unit 'app.v12-04.1'
+
+      expect(unit.isVersion '14.04').toBe false


### PR DESCRIPTION
fixes #13 and #12 

When deploying, a request is now made to the Docker Registry to get the latest
image of the service. The generated serviced file is then locked down to that
image version/tag.
