### PR TITLE
Destroy command specific version support

### DIFF
--- a/src/service.coffee
+++ b/src/service.coffee
@@ -27,3 +27,13 @@ class Service
     q.all [1..@unitCount].map (index) =>
       unitBuilder.build this, version, index
     .then (@units) =>
+
+  # Public: Parse a service name
+  @parseName: (name) ->
+    # check for version in name
+    if string(name).contains ':'
+      version = name.substring name.indexOf(':') + 1
+      name = name.substring 0, name.indexOf ':'
+
+    name: name
+    version: version

--- a/test/service.spec.coffee
+++ b/test/service.spec.coffee
@@ -39,3 +39,13 @@ describe 'service', ->
       service.build unitBuilder, '14.04'
 
       expect(unitBuilder.build).toHaveBeenCalledWith service, '14.04', 1
+
+  describe 'parseName', ->
+    it 'should return just the name if no version is specified', ->
+      expect(Service.parseName 'app').toEqual
+        name: 'app'
+
+    it 'should return just the name and version if a version is specified', ->
+      expect(Service.parseName 'app:14.04').toEqual
+        name: 'app'
+        version: '14.04'


### PR DESCRIPTION
You can now pass a version through to the destroy command e.g
`cordage destroy 14.04`
